### PR TITLE
WIP Issue #108

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -307,7 +307,7 @@ $(document).ready(function() {
       let prospectFile = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
-        if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {
+        if (fileName.startsWith(creditPath) && (creditPath.length > prospectPath.length)) {
           prospect = creditEntry;
           prospectPath = creditPath;
           prospectFile = fileName;

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,8 +302,9 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
-      var prospect = '';
-      var prospectName = '';
+      let prospect = '';
+      let prospectPath = '';
+      let prospectFile = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
         if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,12 +302,14 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
-      let prospect = '';
+      var prospect = '';
+      var prospectName = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
-        if (fileName.startsWith(creditPath) && fileName.length > prospect.length) {
+        if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {
           prospect = creditEntry;
-          console.log(creditEntry.replace(creditPath + ',', fileName + ','));
+          prospectPath = creditPath;
+          prospectFile = fileName;
         }
         if (creditEntry.startsWith(fileName)) {
           return creditEntry;
@@ -316,7 +318,7 @@ $(document).ready(function() {
 
       // Found closest match!
       if (prospect !== '') {
-        return prospect;
+        return prospect.replace(prospectPath, prospectFile);
       }
     }
   }

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,11 +302,22 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
+      let prospect = '';
       for (let creditEntry of parsedCredits) {
+        var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
+        if (fileName.startsWith(creditPath) && fileName.length > prospect.length) {
+          prospect = creditEntry;
+          console.log(creditEntry.replace(creditPath + ',', fileName + ','));
+        }
         if (creditEntry.startsWith(fileName)) {
           return creditEntry;
         }
       };
+
+      // Found closest match!
+      if (prospect !== '') {
+        return prospect;
+      }
     }
   }
 


### PR DESCRIPTION
https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/issues/108

Update the credits loading to dynamically check the path. The longest matching path that isn't an exact match will be the one used.

This is a hypothetical possibility, but needs additional testing. I'd like to make it so it still shows the current image, but if I add this fix in:

`prospect = creditEntry.replace(creditPath + ',', fileName + ','))`

It loses the entire credits list.

Without that line, I get this:
`- hair/extensions/braidl/: by David Conway Jr. (JaidynReiman). License(s): OGA-BY 3.0+, CC-BY 3.0+, CC-BY-SA 3.0, GPL 3.0.`

With that line, I get this:
`- hair/extensions/braidl/adult/carrot.png: by  License(s): `


I'll test it with my next set of releases and see how well it works before opening an official PR.